### PR TITLE
refactor: 调整 响应式 http 请求的方式

### DIFF
--- a/cover.config.ts
+++ b/cover.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from 'laky';
+import { get, set } from 'lodash-es';
 
 export default defineConfig({
   generateApi: {
@@ -6,5 +7,11 @@ export default defineConfig({
     // eslint-disable-next-line node/prefer-global/process
     url: `${process.env.VITE_API_BASE}/docs-json`,
     httpClientType: 'axios',
+    hooks: {
+      onCreateRoute: route => {
+        set(route, ['response', 'type'], get(route, ['response', 'errorType']));
+        return route;
+      }
+    }
   },
 });

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -4,3 +4,4 @@ export * from './useLogoutConfirm';
 export * from './useMessage';
 export * from './usePage';
 export * from './useRefreshPrompt';
+export * from './useRequest';

--- a/src/hooks/useRequest.ts
+++ b/src/hooks/useRequest.ts
@@ -1,0 +1,12 @@
+import type { CommonResponseVo } from '@/services';
+import type { UseAsyncStateOptions } from '@vueuse/core';
+import { getReqOptItem } from '@/utils';
+
+export function useRequest<Data, Shallow extends boolean>(
+  api: () => Promise<CommonResponseVo & { data?: Data }>,
+  initData: Data,
+  options?: UseAsyncStateOptions<Shallow>
+) {
+  const immediate = getReqOptItem(void 0, 'requestImmediate');
+  return useAsyncState(api, { code: 0, msg: '', data: initData }, { ...options, immediate });
+}

--- a/src/interceptors/response.ts
+++ b/src/interceptors/response.ts
@@ -7,7 +7,7 @@ function getRes(ctx: Context) {
 }
 
 export const responseInterceptor: Middleware<Context, Response> = async function (ctx, next) {
-  const resMode = getReqOptItem(ctx as unknown as Context, 'responseMode');
+  const resMode = getReqOptItem(ctx, 'responseMode');
 
   if (resMode === 'object' || resMode === 'array') {
     try {
@@ -23,14 +23,6 @@ export const responseInterceptor: Middleware<Context, Response> = async function
         : [err as Error, void 0];
     }
   }
-
-  // if (resMode === 'reactive') {
-  //   const immediate = getReqOptItem(ctx, 'requestImmediate');
-  //   return useAsyncState<NormalResponse>(async () => {
-  //     await next();
-  //     return ctx.res?.data;
-  //   }, { data: {}, code: 0, msg: '' }, { immediate });
-  // }
 
   // mode = 'normal'
   await next();

--- a/src/interceptors/response.ts
+++ b/src/interceptors/response.ts
@@ -2,13 +2,17 @@ import type { NormalResponse, Response } from '@/types';
 import type { Context, Middleware } from 'onion-interceptor';
 import { getReqOptItem } from '@/utils';
 
+function getRes(ctx: Context) {
+  return ctx.res?.data as unknown as NormalResponse;
+}
+
 export const responseInterceptor: Middleware<Context, Response> = async function (ctx, next) {
-  const resMode = getReqOptItem(ctx, 'responseMode');
+  const resMode = getReqOptItem(ctx as unknown as Context, 'responseMode');
 
   if (resMode === 'object' || resMode === 'array') {
     try {
       await next();
-      const res = ctx.res?.data;
+      const res = getRes(ctx);
       return resMode === 'object'
         ? { err: void 0, res }
         : [void 0, res];
@@ -20,16 +24,15 @@ export const responseInterceptor: Middleware<Context, Response> = async function
     }
   }
 
-  if (resMode === 'reactive') {
-    const immediate = getReqOptItem(ctx, 'requestImmediate');
-    return useAsyncState<NormalResponse>(async () => {
-      await next();
-      return ctx.res?.data;
-    }, { data: {}, code: 0, msg: '' }, { immediate });
-  }
+  // if (resMode === 'reactive') {
+  //   const immediate = getReqOptItem(ctx, 'requestImmediate');
+  //   return useAsyncState<NormalResponse>(async () => {
+  //     await next();
+  //     return ctx.res?.data;
+  //   }, { data: {}, code: 0, msg: '' }, { immediate });
+  // }
 
   // mode = 'normal'
   await next();
-
-  return ctx.res?.data;
+  return getRes(ctx);
 };

--- a/src/pages/system/menu/MenuDrawer.vue
+++ b/src/pages/system/menu/MenuDrawer.vue
@@ -1,7 +1,6 @@
 <script lang="ts" setup>
 import type { CreateMenuDtoWithId } from '@/pages/system/menu/index.vue';
 import type { MenuVo } from '@/services';
-import type { NormalResponse } from '@/types';
 import { useMessage } from '@/hooks';
 import { api } from '@/services';
 
@@ -41,12 +40,12 @@ async function onSubmit() {
       formData.parentId = null as unknown as number; // 现在先这样 等后端改了再改
     }
     if (props.type) {
-      const res = await api.system.menuCreate(formData) as unknown as NormalResponse;
+      const res = await api.system.menuCreate(formData);
       handleResponse(res, '新增成功');
     }
     else {
       const id = formData.id!;
-      const res = await api.system.menuUpdate(id, formData) as unknown as NormalResponse;
+      const res = await api.system.menuUpdate(id, formData);
       handleResponse(res, '修改成功');
     }
   }

--- a/src/pages/system/menu/index.vue
+++ b/src/pages/system/menu/index.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import type { CreateMenuDto, MenuVo } from '@/services';
-import type { ReactiveResponse } from '@/types';
 import AsyncIcon from '@/components/SubMenu/AsyncIcon.vue';
+import { useRequest } from '@/hooks';
 import { api } from '@/services';
 
 import { DeleteOutlined, EditOutlined } from '@ant-design/icons-vue';
@@ -95,11 +95,13 @@ const treeTableData = computed(() => {
   return generateTreeDataWithKey(tableData.value);
 });
 
-const { isLoading, error, execute, state } = await api.system.menuFindList({ customOptions: { responseMode: 'reactive' } }) as unknown as ReactiveResponse<MenuVo[]>;
+// const { isLoading, error, execute, state } = await api.system.menuFindList({ customOptions: { responseMode: 'reactive' } }) as unknown as ReactiveResponse<MenuVo[]>;
+const { isLoading, error, execute, state } = useRequest(api.system.menuFindList, []);
+
 async function fetchData() {
   await execute();
   if (!error.value) {
-    tableData.value = state.value.data;
+    tableData.value = state.value.data!;
   }
 }
 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -267,7 +267,7 @@ export interface CommonResponseVo {
   msg: string;
 }
 
-import type { AxiosInstance, AxiosRequestConfig, AxiosResponse, HeadersDefaults, ResponseType } from "axios";
+import type { AxiosInstance, AxiosRequestConfig, HeadersDefaults, ResponseType } from "axios";
 import axios from "axios";
 import type { CustomRequestOptions } from "../types";
 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -376,7 +376,7 @@ export class HttpClient<SecurityDataType = unknown> {
     format,
     body,
     ...params
-  }: FullRequestParams): Promise<AxiosResponse<T>> => {
+  }: FullRequestParams)=> {
     const secureParams =
       ((typeof secure === "boolean" ? secure : this.secure) &&
         this.securityWorker &&
@@ -393,7 +393,7 @@ export class HttpClient<SecurityDataType = unknown> {
       body = JSON.stringify(body);
     }
 
-    return this.instance.request({
+    return this.instance.request<any,T>({
       ...requestParams,
       headers: {
         ...(requestParams.headers || {}),
@@ -429,7 +429,9 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      */
     authLogin: (data: AccountLoginDto, params: RequestParams = {}) =>
       this.request<
-        any,
+        CommonResponseVo & {
+          data?: AccountLoginVo;
+        },
         CommonResponseVo & {
           data?: AccountLoginVo;
         }
@@ -451,7 +453,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @secure
      */
     authLogout: (params: RequestParams = {}) =>
-      this.request<any, CommonResponseVo>({
+      this.request<CommonResponseVo, CommonResponseVo>({
         path: `/auth/logout`,
         method: "POST",
         secure: true,
@@ -470,7 +472,9 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      */
     profileFindUserInfo: (params: RequestParams = {}) =>
       this.request<
-        any,
+        CommonResponseVo & {
+          data?: ProfileVo;
+        },
         CommonResponseVo & {
           data?: ProfileVo;
         }
@@ -491,7 +495,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @secure
      */
     profileUpdateUserInfo: (data: UpdateProfileDto, params: RequestParams = {}) =>
-      this.request<any, CommonResponseVo>({
+      this.request<CommonResponseVo, CommonResponseVo>({
         path: `/profile/update`,
         method: "PATCH",
         body: data,
@@ -510,7 +514,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @secure
      */
     profileUpdatePassword: (data: UpdatePasswordDto, params: RequestParams = {}) =>
-      this.request<any, CommonResponseVo>({
+      this.request<CommonResponseVo, CommonResponseVo>({
         path: `/profile/updatePassword`,
         method: "PATCH",
         body: data,
@@ -530,7 +534,9 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      */
     profileGetMenus: (params: RequestParams = {}) =>
       this.request<
-        any,
+        CommonResponseVo & {
+          data?: MenuVo[];
+        },
         CommonResponseVo & {
           data?: MenuVo[];
         }
@@ -552,7 +558,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @secure
      */
     userCreate: (data: CreateUserDto, params: RequestParams = {}) =>
-      this.request<any, CommonResponseVo>({
+      this.request<CommonResponseVo, CommonResponseVo>({
         path: `/system/user`,
         method: "POST",
         body: data,
@@ -598,7 +604,9 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       params: RequestParams = {},
     ) =>
       this.request<
-        any,
+        CommonResponseVo & {
+          data?: UserInfoVo[];
+        },
         CommonResponseVo & {
           data?: UserInfoVo[];
         }
@@ -646,7 +654,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       },
       params: RequestParams = {},
     ) =>
-      this.request<any, File>({
+      this.request<File, File>({
         path: `/system/user/export`,
         method: "GET",
         query: query,
@@ -664,7 +672,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @secure
      */
     roleCreate: (data: CreateRoleDto, params: RequestParams = {}) =>
-      this.request<any, CommonResponseVo>({
+      this.request<CommonResponseVo, CommonResponseVo>({
         path: `/system/role`,
         method: "POST",
         body: data,
@@ -702,7 +710,9 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       params: RequestParams = {},
     ) =>
       this.request<
-        any,
+        CommonResponseVo & {
+          data?: RoleVo[];
+        },
         CommonResponseVo & {
           data?: RoleVo[];
         }
@@ -724,7 +734,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @secure
      */
     roleRemove: (id: number, params: RequestParams = {}) =>
-      this.request<any, CommonResponseVo>({
+      this.request<CommonResponseVo, CommonResponseVo>({
         path: `/system/role/${id}`,
         method: "DELETE",
         secure: true,
@@ -741,7 +751,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @secure
      */
     roleUpdate: (id: number, data: UpdateRoleDto, params: RequestParams = {}) =>
-      this.request<any, CommonResponseVo>({
+      this.request<CommonResponseVo, CommonResponseVo>({
         path: `/system/role/${id}`,
         method: "PATCH",
         body: data,
@@ -760,7 +770,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @secure
      */
     menuCreate: (data: CreateMenuDto, params: RequestParams = {}) =>
-      this.request<any, CommonResponseVo>({
+      this.request<CommonResponseVo, CommonResponseVo>({
         path: `/system/menu`,
         method: "POST",
         body: data,
@@ -780,7 +790,9 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      */
     menuFindList: (params: RequestParams = {}) =>
       this.request<
-        any,
+        CommonResponseVo & {
+          data?: MenuVo[];
+        },
         CommonResponseVo & {
           data?: MenuVo[];
         }
@@ -801,7 +813,7 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
      * @secure
      */
     menuUpdate: (id: number, data: UpdateMenuDto, params: RequestParams = {}) =>
-      this.request<any, CommonResponseVo>({
+      this.request<CommonResponseVo, CommonResponseVo>({
         path: `/system/menu/${id}`,
         method: "PATCH",
         body: data,
@@ -827,7 +839,9 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       params: RequestParams = {},
     ) =>
       this.request<
-        any,
+        CommonResponseVo & {
+          data?: string;
+        },
         CommonResponseVo & {
           data?: string;
         }
@@ -854,7 +868,9 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       params: RequestParams = {},
     ) =>
       this.request<
-        any,
+        CommonResponseVo & {
+          data?: string;
+        },
         CommonResponseVo & {
           data?: string;
         }
@@ -884,7 +900,9 @@ export class Api<SecurityDataType extends unknown> extends HttpClient<SecurityDa
       params: RequestParams = {},
     ) =>
       this.request<
-        any,
+        CommonResponseVo & {
+          data?: string;
+        },
         CommonResponseVo & {
           data?: string;
         }

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -1,6 +1,6 @@
 import type { MenuData, MenuDataItem } from '@/router/types.ts';
 
-import type { LayoutSetting, NormalResponse, PageTagItem, ThemeType } from '@/types';
+import type { LayoutSetting, PageTagItem, ThemeType } from '@/types';
 import type { ThemeConfig } from 'ant-design-vue/es/config-provider/context';
 import type { Router } from 'vue-router';
 import { PageEnum } from '@/enums';
@@ -112,7 +112,7 @@ export const useAppStore = defineStore('app', () => {
    * @returns {Promise<any>} 返回生成的菜单和路由数据
    */
   async function getMenuData() {
-    const res = await api.profile.profileGetMenus() as unknown as NormalResponse;
+    const res = await api.profile.profileGetMenus();
     return generateMenuAndRoutes(res.data);
   }
 

--- a/src/store/user.ts
+++ b/src/store/user.ts
@@ -22,7 +22,6 @@ export const useUserStore = defineStore(
     } = useTimeoutPoll(
       async () => {
         const [err, res] = await api.profile.profileFindUserInfo({ customOptions: { responseMode: 'array' } }) as unknown as ArrayResponse<UserInfoVo>;
-
         if (err)
           return;
 
@@ -43,7 +42,6 @@ export const useUserStore = defineStore(
           responseMode: 'array'
         },
       }) as unknown as ArrayResponse;
-
       if (err)
         throw err;
 

--- a/src/types/request.ts
+++ b/src/types/request.ts
@@ -1,9 +1,8 @@
 import type { ApiConfig, CommonResponseVo, RequestParams } from '@/services';
-import type { UseAsyncStateReturnBase } from '@vueuse/core';
 
 export type ErrorMessageMode = 'none' | 'modal' | 'message' | void;
 export type SuccessMessageMode = ErrorMessageMode;
-export type ResponseMode = 'normal' | 'reactive' | 'object' | 'array';
+export type ResponseMode = 'normal' | 'object' | 'array';
 
 export interface CustomRequestOptions {
   loadingInterceptorEnabled?: boolean
@@ -29,8 +28,6 @@ export interface ObjectResponse<Data = any> {
 
 export type ArrayResponse<Data = any> = [Error | void, NormalResponse<Data> | void];
 
-export type ReactiveResponse<Data = any> = UseAsyncStateReturnBase<NormalResponse<Data>, any[], boolean>;
-
-export type Response = NormalResponse | ObjectResponse | ArrayResponse | ReactiveResponse;
+export type Response<Data = any> = NormalResponse<Data> | ObjectResponse<Data> | ArrayResponse<Data>;
 
 export { ApiConfig, RequestParams };

--- a/src/utils/getReqOptItem.ts
+++ b/src/utils/getReqOptItem.ts
@@ -10,7 +10,10 @@ function _getVal(
 ) {
   return get(obj, ['customOptions', key]);
 }
-export function getReqOptItem(ctx: Context, key: keyof CustomRequestOptions) {
+export function getReqOptItem(ctx: Context | void, key: keyof CustomRequestOptions) {
+  if (!ctx)
+    return DEFAULT[key];
+
   const [params] = ctx?.args as [RequestParams];
   const config = ctx?.cfg;
 


### PR DESCRIPTION
1. 调整 api 生成模版，使得返回类型提示正确
2. 加入 useRequest 用于 业务中 响应式调用 api 的场景